### PR TITLE
chore: normalize repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/sanity-io/prettier-config.git"
+    "url": "git+https://github.com/sanity-io/prettier-config.git"
   },
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",


### PR DESCRIPTION
## Summary

- normalize the package `repository.url` from SSH-style Git metadata to HTTPS Git metadata
- keep the change limited to `package.json`

## Why

The current npm metadata for `@sanity/prettier-config@3.0.0` exposes:

```json
"repository": {
  "type": "git",
  "url": "git+ssh://git@github.com/sanity-io/prettier-config.git"
}
```

That works for contributors with SSH configured, but HTTPS metadata is friendlier for package consumers, registries, and read-only tooling that expects a public clone URL.

## Validation

```bash
node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/sanity-io/prettier-config.git') process.exit(1); console.log(JSON.stringify({name:p.name, version:p.version, repository:p.repository}))"
git diff --check
npm pack --dry-run --ignore-scripts --json .
```
