### PR TITLE
fix: use HTTPS repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/sanity-io/prettier-config.git"
+    "url": "git+https://github.com/sanity-io/prettier-config.git"
   },
   "license": "MIT",
   "author": "Sanity.io <hello@sanity.io>",


### PR DESCRIPTION
## Summary
Change repository URL from SSH to HTTPS for better public accessibility.

## Issue
The package.json currently uses  as the repository URL. This requires GitHub SSH setup for metadata consumers. Switching to the HTTPS URL () makes the metadata universally accessible.

## Related
- Bounty: charles-openclaw/charles-microbounties#1955
- Original discovery credit to @jakerated-r

## Change
- : repository url  → 